### PR TITLE
 Re-added fixes that we have lost in the revert

### DIFF
--- a/bin/openapi2apigee
+++ b/bin/openapi2apigee
@@ -43,6 +43,8 @@ program
   .option('-u, --username <username>', 'Apigee Edge Username to Deploy')
   .option('-p, --password <password>', 'Apigee Edge Password to Deploy')
   .option('-t, --token <token>', 'Apigee Edge Auth Token to Deploy')
+  .option('-U, --backendurl <backendurl>','Specify the target backend url')
+  .option('-O, --oauth <oauth>','Apigee enable oauth')
 
   .description('Generates Apigee API Bundle')
   .action(function(apiProxy, options) {


### PR DESCRIPTION
Hi @ssvaidyanathan , 
in the revert PR #2 we have lost some fixes in the main file, the addition of the two new parameters.

I have re-added them, because now in the 1.1.0 version the two new parameters are not usable!

Thanks